### PR TITLE
Add travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,18 @@
+sudo: required
+
+# It is not really needed, other than for showing correct language tag in Travis CI build log.
+language: c
+compiler:
+  - gcc
+  - clang
+
+before_install:
+  - docker run -d --name travis-ci -v $(pwd):/travis ubuntu:xenial tail -f /dev/null
+  - docker ps
+
+install:
+  - docker exec -t travis-ci bash -c "apt-get update;
+    apt-get install -y libnl-3-dev libnl-3-200 libnl-route-3-200 libnl-genl-3-200 libnl-route-3-dev libnl-genl-3-dev libjansson-dev libev-dev build-essential autoconf automake pkg-config clang"
+
+script:
+  - docker exec -t travis-ci bash -c "cd /travis; ./autogen.sh && ./configure && make"

--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Build Status](https://travis-ci.com/westermo/dhcp-helper.svg?branch=master)](https://travis-ci.com/westermo/dhcp-helper)
 # dhcp-helper
 
 This DHCP relay agent is originally written by Simon Kelley


### PR DESCRIPTION
Add travis support, build in a custom docker since it is required at least ubuntu 16.04 to build, needs a newer libnl.