### PR TITLE
bridge: Add incoming clients to bridge fdb

### DIFF
--- a/src/include/misc.h
+++ b/src/include/misc.h
@@ -23,5 +23,5 @@
 int setup_nftables(cfg_t *cfg);
 void cleanup_nftables();
 int add_arp_entry(int ifindex, unsigned char *mac, struct sockaddr_in saddr);
-
+int add_fdb_entry(int ifindex, unsigned char *mac);
 #endif

--- a/src/misc.c
+++ b/src/misc.c
@@ -152,10 +152,10 @@ void cleanup_nftables()
 int add_fdb_entry(int ifindex, unsigned char *mac)
 {
 	int err;
-        struct nl_addr *addr;
-        struct rtnl_neigh *neigh;
-        struct nl_sock *sk;
-        sk = nl_socket_alloc();
+	struct nl_addr *addr;
+	struct rtnl_neigh *neigh;
+	struct nl_sock *sk;
+	sk = nl_socket_alloc();
 
 	if (!sk)
 		return 1;
@@ -172,13 +172,13 @@ int add_fdb_entry(int ifindex, unsigned char *mac)
 		nl_socket_free(sk);
 		return 1;
 	}
-        addr = nl_addr_alloc(ETH_ALEN);
-        if (!addr) {
+	addr = nl_addr_alloc(ETH_ALEN);
+	if (!addr) {
 		syslog2(LOG_ERR, "Could not allocate netlink address");
 		err = -NLE_NOMEM;
-                nl_socket_free(sk);
-                return 1;
-        }
+		nl_socket_free(sk);
+		return 1;
+	}
 
 	syslog2(LOG_DEBUG, "Interface %d is bridged, adding FDB entry", ifindex);
 	nl_addr_set_family(addr, AF_LLC);

--- a/src/misc.c
+++ b/src/misc.c
@@ -142,6 +142,72 @@ void cleanup_nftables()
 		syslog2(LOG_ERR, "Failed deleting nftables forward rules");
 }
 
+/**
+   If there is an underlaying switchcore, it may implement 'DHCP-snooping',
+   in this case it will most likely not learn the MAC-address correctly.
+
+   To fix this, add a FDB entry in the bridge, if there are a switch under
+   the FDB entry will be accelerated.
+ */
+int add_fdb_entry(int ifindex, unsigned char *mac)
+{
+	int err;
+        struct nl_addr *addr;
+        struct rtnl_neigh *neigh;
+        struct nl_sock *sk;
+        sk = nl_socket_alloc();
+
+	if (!sk)
+		return 1;
+
+	err = nl_connect(sk, NETLINK_ROUTE);
+	if (err) {
+		nl_socket_free(sk);
+		syslog(LOG_ERR, "Failed setting connecting to NETLINK_ROUTE: %s", nl_geterror(err));
+		return 1;
+	}
+
+	if (!iface_is_bridged(sk, ifindex)) {
+		syslog2(LOG_DEBUG, "Interface %d is not bridged, skipping FDB entry", ifindex);
+		nl_socket_free(sk);
+		return 1;
+	}
+        addr = nl_addr_alloc(ETH_ALEN);
+        if (!addr) {
+		syslog2(LOG_ERR, "Could not allocate netlink address");
+		err = -NLE_NOMEM;
+                nl_socket_free(sk);
+                return 1;
+        }
+
+	syslog2(LOG_DEBUG, "Interface %d is bridged, adding FDB entry", ifindex);
+	nl_addr_set_family(addr, AF_LLC);
+	err = nl_addr_set_binary_addr(addr, mac, ETH_ALEN);
+	if (err) {
+		syslog(LOG_ERR, "Failed creating netlink binary address: %s", nl_geterror(err));
+		nl_socket_free(sk);
+		return 1;
+	}
+
+	neigh = rtnl_neigh_alloc();
+	if (!neigh) {
+		nl_addr_put(addr);
+		nl_socket_free(sk);
+		return 1;
+	}
+	rtnl_neigh_set_family(neigh, PF_BRIDGE);
+	rtnl_neigh_set_lladdr(neigh, addr);
+	nl_addr_set_prefixlen(addr, 48);
+	rtnl_neigh_set_flags(neigh, NTF_MASTER);
+	rtnl_neigh_set_state(neigh, NUD_REACHABLE);
+	rtnl_neigh_set_ifindex(neigh, ifindex);
+
+	syslog(LOG_DEBUG, "Adding MAC %02x:%02x:%02x:%02x:%02x:%02x ifindex %d in bridge FDB", mac[0],mac[1],mac[2],mac[3],mac[4],mac[5], ifindex);
+	err = rtnl_neigh_add(sk, neigh, NLM_F_CREATE); //NLM_F_CREATE);
+
+	return err;
+}
+
 int add_arp_entry(int ifindex, unsigned char *mac, struct sockaddr_in saddr)
 {
 	struct arpreq req;

--- a/src/packet.c
+++ b/src/packet.c
@@ -144,6 +144,11 @@ static int handle_request(cfg_t *cfg, struct dhcp_packet *packet, int ifindex, s
 			while (sendto(send_sd, packet, sz, 0, (struct sockaddr *)&saddr, sizeof(saddr)) == -1 && errno == EINTR) ;
 		}
 	}
+        if (add_fdb_entry(ifindex, packet->chaddr)) {
+		syslog2(LOG_ERR, "Failed adding FDB entry to bridge");
+		return 1;
+        }
+
 	return 0;
 }
 

--- a/src/packet.c
+++ b/src/packet.c
@@ -144,7 +144,7 @@ static int handle_request(cfg_t *cfg, struct dhcp_packet *packet, int ifindex, s
 			while (sendto(send_sd, packet, sz, 0, (struct sockaddr *)&saddr, sizeof(saddr)) == -1 && errno == EINTR) ;
 		}
 	}
-        if (add_fdb_entry(ifindex, packet->chaddr)) {
+	if (add_fdb_entry(ifindex, packet->chaddr)) {
 		syslog2(LOG_ERR, "Failed adding FDB entry to bridge");
 		return 1;
         }


### PR DESCRIPTION
This is only required if running on a unit that has a switchcore,
that may not always learn the MAC address on DHCP packet.

If you don't have this setup (a normal linux bridge)  this should
not break anything.